### PR TITLE
Nonimported ignore

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -9,11 +9,13 @@ This package will pull LDAP data, compare state of cloudshell group, and add/rem
 
 ### Important Notes 
 
-- This package does NOT import users from LDAP. Only Syncs already imported Users
-  - Users must be first [manually imported](https://help.quali.com/Online%20Help/0.0/Portal/Content/Admn/AD-Imprt-Usrs-frm-AD-grp-file.htm) or [auto-imported on login](https://help.quali.com/Online%20Help/0.0/Portal/Content/Admn/AD-Intg-Auto-Imprt.htm?tocpath=CloudShell%20Administration%7CCloudShell%20Identity%20Management%7CAccess%20Control%20and%20Authentication%7CActive%20Directory%20Integration%7C_____1) 
-- Non-imported users added to a cloudshell group that don't exist in LDAP will be removed from that cloudshell group.
-  - This tool expects to fully manage the configured cloudshell groups. 
-  - This tool can be configured to manage only a subset of cloudshell groups
+- This package does NOT import users from LDAP. Only Syncs already imported Users.
+  - Users must be first [manually imported](https://help.quali.com/Online%20Help/0.0/Portal/Content/Admn/AD-Imprt-Usrs-frm-AD-grp-file.htm) or [auto-imported on login](https://help.quali.com/Online%20Help/0.0/Portal/Content/Admn/AD-Intg-Auto-Imprt.htm?tocpath=CloudShell%20Administration%7CCloudShell%20Identity%20Management%7CAccess%20Control%20and%20Authentication%7CActive%20Directory%20Integration%7C_____1). 
+- Non-imported cloudshell users will NOT be evicted from groups if they aren't present in the mapped LDAP group.
+  - This tool only aims to manage ldap users from designated groups. 
+- This tool can be configured to manage only a subset of cloudshell groups, doesn't have to be globallly configured.
+- To improve performance of LDAP search, place the target ldap groups to sync close together in LDAP Tree
+  - This will allow to set a lower base_dn to search for users in and quicker ldap searches.
 
 
 ### Installation

--- a/tests/unit/test_group_calculate.py
+++ b/tests/unit/test_group_calculate.py
@@ -20,7 +20,17 @@ def generate_mock_cs_group(group_name, users: List[str]):
 
 @pytest.fixture(scope="module")
 def import_data() -> List[ImportGroupData]:
-    data_list = [ImportGroupData(ldap_group_cn="AD Users", target_cloudshell_groups=["SE"], users=["user1", "user3"])]
+    data_list = [
+        ImportGroupData(ldap_group_cn="AD Users 1",
+                        target_cloudshell_groups=["QA"],
+                        users=["user1", "user2"]),
+        ImportGroupData(ldap_group_cn="AD Users 2",
+                        target_cloudshell_groups=["SE"],
+                        users=["user3", "user4", "user6"]),
+        ImportGroupData(ldap_group_cn="AD Users 3",
+                        target_cloudshell_groups=["DEV"],
+                        users=["user5"]),
+    ]
     return data_list
 
 
@@ -29,7 +39,7 @@ def cs_db_groups() -> cloudshell_sync.CloudshellGroupInfoMap:
     """cloudshell group name mapped to GroupInfo"""
     return {
         "QA": generate_mock_cs_group("QA", ["user1", "user2"]),
-        "SE": generate_mock_cs_group("SE", ["user3", "user4"]),
+        "SE": generate_mock_cs_group("SE", ["user3", "user4", "user22"]),
         "DEV": generate_mock_cs_group("DEV", ["user5", "user6"]),
     }
 
@@ -37,12 +47,14 @@ def cs_db_groups() -> cloudshell_sync.CloudshellGroupInfoMap:
 @pytest.fixture(scope="module")
 def cs_users_set() -> cloudshell_sync.CloudshellGroupInfoMap:
     """cloudshell group name mapped to GroupInfo"""
-    return {"user1", "user2", "user3", "user4", "user5", "user6"}
+    return {"user1", "user2", "user3", "user4", "user5", "user6", "user7"}
 
 
 def test_calculate_groups(import_data, cs_db_groups, cs_users_set):
     to_add_table, to_remove_table = cloudshell_sync.calculate_groups_to_add_and_delete(
         import_data_list=import_data, cs_db_groups=cs_db_groups, all_cs_users_set=cs_users_set
     )
-    assert "user1" in to_add_table["SE"]
-    assert "user4" in to_remove_table["SE"]
+    assert "user6" in to_add_table["SE"]
+    assert "user6" in to_remove_table["DEV"]
+    assert "SE" not in to_remove_table
+    pass

--- a/tests/unit/test_group_calculate.py
+++ b/tests/unit/test_group_calculate.py
@@ -21,15 +21,9 @@ def generate_mock_cs_group(group_name, users: List[str]):
 @pytest.fixture(scope="module")
 def import_data() -> List[ImportGroupData]:
     data_list = [
-        ImportGroupData(ldap_group_cn="AD Users 1",
-                        target_cloudshell_groups=["QA"],
-                        users=["user1", "user2"]),
-        ImportGroupData(ldap_group_cn="AD Users 2",
-                        target_cloudshell_groups=["SE"],
-                        users=["user3", "user4", "user6"]),
-        ImportGroupData(ldap_group_cn="AD Users 3",
-                        target_cloudshell_groups=["DEV"],
-                        users=["user5"]),
+        ImportGroupData(ldap_group_cn="AD Users 1", target_cloudshell_groups=["QA"], users=["user1", "user2"]),
+        ImportGroupData(ldap_group_cn="AD Users 2", target_cloudshell_groups=["SE"], users=["user3", "user4", "user6"]),
+        ImportGroupData(ldap_group_cn="AD Users 3", target_cloudshell_groups=["DEV"], users=["user5"]),
     ]
     return data_list
 


### PR DESCRIPTION
don't evict non-imported users
- allows for mix of imported and non imported users in a "managed" sync group