### PR TITLE
Deprecate winservice

### DIFF
--- a/src/cloudshell_user_sync/cli.py
+++ b/src/cloudshell_user_sync/cli.py
@@ -5,9 +5,6 @@ from cloudshell_user_sync import exceptions
 from cloudshell_user_sync.commands import set_config, set_credential, set_mapping, sync_groups
 
 
-# from cloudshell_user_sync.commands import run_scheduler, run_service  # DEPRECATED - leaving for reference
-
-
 @click.group()
 def cli():
     pass
@@ -70,22 +67,3 @@ def mapping(ldapgroup, csgroups, delete):
         click.secho(f"LDAP Group '{ldapgroup}' Deleted", fg="green")
     elif not any(params):
         set_mapping.view_mappings()
-
-
-"""
-DEPRECATING this command due to limitation of service not working properly in venv, only global python
-Recommended to implement "usersync run" into Windows Task Scheduler or Linux Cron Job 
-@cli.command()
-@click.argument("action", required=True, type=click.Choice(["install", "update", "start"], case_sensitive=True))
-def service(action):
-    click.echo(f"Running service '{action}' action")
-    run_service.run_service_flow()
-"""
-
-"""
-DEPRECATING this command as running a scheduled loop will waste resources while sleeping in between jobs
-Recommended to implement "usersync run" into Windows Task Scheduler or Linux Cron Job on host server
-@cli.command()
-def runscheduler():
-    run_scheduler.run_scheduled_jobs()
-"""

--- a/src/cloudshell_user_sync/cli.py
+++ b/src/cloudshell_user_sync/cli.py
@@ -2,7 +2,10 @@ import click
 import pkg_resources
 
 from cloudshell_user_sync import exceptions
-from cloudshell_user_sync.commands import run_scheduler, run_service, set_config, set_credential, set_mapping, sync_groups
+from cloudshell_user_sync.commands import set_config, set_credential, set_mapping, sync_groups
+
+
+# from cloudshell_user_sync.commands import run_scheduler, run_service  # DEPRECATED - leaving for reference
 
 
 @click.group()
@@ -20,20 +23,6 @@ def version():
 def run():
     """Pull LDAP Data and sync to Cloudshell"""
     sync_groups.sync_groups_flow()
-
-
-@cli.command()
-def runscheduler():
-    """Run sync on infinite scheduler"""
-    run_scheduler.run_scheduled_jobs()
-
-
-@cli.command()
-@click.argument("action", required=True, type=click.Choice(["install", "update", "start"], case_sensitive=True))
-def service(action):
-    """Install Windows service to run job automatically"""
-    click.echo(f"Running service '{action}' action")
-    run_service.run_service_flow()
 
 
 @cli.command()
@@ -81,3 +70,22 @@ def mapping(ldapgroup, csgroups, delete):
         click.secho(f"LDAP Group '{ldapgroup}' Deleted", fg="green")
     elif not any(params):
         set_mapping.view_mappings()
+
+
+"""
+DEPRECATING this command due to limitation of service not working properly in venv, only global python
+Recommended to implement "usersync run" into Windows Task Scheduler or Linux Cron Job 
+@cli.command()
+@click.argument("action", required=True, type=click.Choice(["install", "update", "start"], case_sensitive=True))
+def service(action):
+    click.echo(f"Running service '{action}' action")
+    run_service.run_service_flow()
+"""
+
+"""
+DEPRECATING this command as running a scheduled loop will waste resources while sleeping in between jobs
+Recommended to implement "usersync run" into Windows Task Scheduler or Linux Cron Job on host server
+@cli.command()
+def runscheduler():
+    run_scheduler.run_scheduled_jobs()
+"""

--- a/src/cloudshell_user_sync/commands/run_scheduler.py
+++ b/src/cloudshell_user_sync/commands/run_scheduler.py
@@ -1,3 +1,6 @@
+"""
+DEPRECATED - leaving for reference
+"""
 from cloudshell_user_sync.utility import config_handler, path_helper, safe_echo
 from cloudshell_user_sync.utility.rotating_log_handler import get_rotating_logger
 from cloudshell_user_sync.utility.schedule_handler import ScheduleHandler

--- a/src/cloudshell_user_sync/commands/run_service.py
+++ b/src/cloudshell_user_sync/commands/run_service.py
@@ -1,3 +1,6 @@
+"""
+DEPRECATED - leaving for reference
+"""
 import platform
 import sys
 

--- a/src/cloudshell_user_sync/utility/schedule_handler.py
+++ b/src/cloudshell_user_sync/utility/schedule_handler.py
@@ -1,4 +1,7 @@
 """
+DEPRECATED - leaving for reference
+The original idea was to have cross-platform scheduler
+More efficient to schedule jobs via OS and save resources on needless sleeps
 https://github.com/dbader/schedule
 """
 import time

--- a/src/cloudshell_user_sync/utility/windows_service.py
+++ b/src/cloudshell_user_sync/utility/windows_service.py
@@ -1,3 +1,6 @@
+"""
+DEPRECATED - recommended to schedule jobs via OS scheduler (Task Scheduler / Cron)
+"""
 import socket
 
 import servicemanager


### PR DESCRIPTION
deprecating windows service to simplify implementation. 

Windows service is not easily supported in venv.

Users should use OS level task schedulers to run this such as Task Scheduler or Cron Job